### PR TITLE
Log enum types

### DIFF
--- a/KoalaLogger/src/main/java/Ori/Coval/Logging/Logger/KoalaLog.java
+++ b/KoalaLogger/src/main/java/Ori/Coval/Logging/Logger/KoalaLog.java
@@ -166,6 +166,18 @@ public class KoalaLog {
         return value;
     }
 
+    public static <E extends Enum<E>> E log(String name, E value, boolean post) {
+        final long ts = nowMicros();
+        enqueue(() -> SingleCoreKoalaLog.log(name, value.name(), post, ts));
+        return value;
+    }
+
+    public static <E extends Enum<E>> E log(String name, E value, boolean post, String metadata) {
+        final long ts = nowMicros();
+        enqueue(() -> SingleCoreKoalaLog.log(name, value.name(), post, metadata, ts));
+        return value;
+    }
+
     public static String log(String name, String value, boolean post) {
         final long ts = nowMicros();
         enqueue(() -> SingleCoreKoalaLog.log(name, value, post, ts));

--- a/KoalaLogger/src/main/java/Ori/Coval/Logging/ReflectionLogger.java
+++ b/KoalaLogger/src/main/java/Ori/Coval/Logging/ReflectionLogger.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import Ori.Coval.Logging.Logger.KoalaLog;
-import Ori.Coval.Logging.Logger.KoalaLog;
 
 /**
  * TelemetryManager: automatically logs all fields, zero-arg methods, and suppliers
@@ -106,6 +105,8 @@ public class ReflectionLogger {
             KoalaLog.log(name, (double) value, post);
         } else if (type == String.class) {
             KoalaLog.log(name, value.toString(), post);
+        } else if (type.isEnum()) {
+            KoalaLog.log(name, ((Enum<?>) value).name(), post);
         }
         else if (type.isArray()) {
             Class<?> ct = type.getComponentType();

--- a/KoalaLoggingProcessor/src/main/java/Ori/Coval/FtcAutoLog/AutoLogAnnotationProcessor.java
+++ b/KoalaLoggingProcessor/src/main/java/Ori/Coval/FtcAutoLog/AutoLogAnnotationProcessor.java
@@ -616,6 +616,14 @@ public class AutoLogAnnotationProcessor extends AbstractProcessor {
         return e == null ? null : ((PackageElement) e).getQualifiedName().toString();
     }
 
+    private boolean isEnumType(TypeMirror tm) {
+        if (tm.getKind() == TypeKind.DECLARED) {
+            Element elem = processingEnv.getTypeUtils().asElement(tm);
+            return elem != null && elem.getKind() == ElementKind.ENUM;
+        }
+        return false;
+    }
+
     private boolean isLoggableType(TypeMirror tm) {
         TypeKind k = tm.getKind();
 
@@ -639,7 +647,10 @@ public class AutoLogAnnotationProcessor extends AbstractProcessor {
             }
         }
 
-        // 3) arrays of any of the above (including wrapper arrays, primitive arrays, String[])
+        // 3) enums
+        if (isEnumType(tm)) return true;
+
+        // 4) arrays of any of the above (including wrapper arrays, primitive arrays, String[])
         if (k == TypeKind.ARRAY) {
             ArrayType at = (ArrayType) tm;
             return isLoggableType(at.getComponentType());


### PR DESCRIPTION
Adds support to log enum types through KoalaLog.log, `@AutoLog` and ReflectionLogger. It will log the string value of the enum.