### PR TITLE
Fix struct schemas missing from second log file when reopening logger

### DIFF
--- a/KoalaLogger/src/main/java/Ori/Coval/Logging/Logger/KoalaLogCore.java
+++ b/KoalaLogger/src/main/java/Ori/Coval/Logging/Logger/KoalaLogCore.java
@@ -79,6 +79,7 @@ public class KoalaLogCore implements Closeable {
             largestId = 0;
             startTime = System.nanoTime() / 1000;
             fake = fakeLog;
+            SchemaRegistry.reset();
 
             if (fake) {
                 // In fake mode we intentionally do not call LogFileManager.setup()
@@ -113,6 +114,7 @@ public class KoalaLogCore implements Closeable {
 
             recordIDs.clear();
             largestId = 0;
+            SchemaRegistry.reset();
         }
     }
     public static void flush() {

--- a/KoalaLogger/src/main/java/Ori/Coval/Logging/Logger/SchemaRegistry.java
+++ b/KoalaLogger/src/main/java/Ori/Coval/Logging/Logger/SchemaRegistry.java
@@ -39,5 +39,9 @@ public class SchemaRegistry {
         registerStructSchemas("struct:Rotation2d", "double value");
         registerStructSchemas("struct:Pose2d", "Translation2d translation;Rotation2d rotation");
     }
+
+    static void reset() {
+        structSchemas.clear();
+    }
 }
 


### PR DESCRIPTION
## Issue

`SchemaRegistry.structSchemas` is a static cache that was never cleared between logs, so `registerStructSchemas` only adds the struct definitions to the first log.

## Steps to reproduce

Call setup() → start() → stop() → setup() to produce a second .wpilog with no Pose2d struct definitions, which made pose data unreadable in Advantage Scope.

## Fix

Added `SchemaRegistry.reset()` and call it from `KoalaLogCore.setup()` and `KoalaLogCore.closeLog()` so the schema cache mirrors the lifetime of the underlying log file.